### PR TITLE
Handle HTTP Connection Closing

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -287,6 +287,8 @@ handle_sock_data(Data, #state{status = get_header}=State) ->
         {error, _Reason} ->
             shutting_down(State),
             {stop, normal, State};
+        #state{is_closing = true} ->
+            {stop, normal, State};
         #state{socket = Socket, status = Status, cur_req = CurReq} = State_1 ->
             case {Status, CurReq} of
                 {get_header, #request{caller_controls_socket = true}} ->


### PR DESCRIPTION
When a connection is closed by the HTTP upstream, `ibrowse` continues to use the connection for future requests.

```
2> ibrowse:set_dest("localhost", 4567, [{max_sessions, 1}]).
ok
3> ibrowse:send_req("http://localhost:4567", [], get).      
{ok,"200",
    [{"Content-Type","text/html;charset=utf-8"},
     {"Connection","close"},
     {"Content-Length","40"},
     {"X-XSS-Protection","1; mode=block"},
     {"X-Content-Type-Options","nosniff"},
     {"X-Frame-Options","SAMEORIGIN"},
     {"Server","thin 1.5.1 codename Straight Razor"}],
    "I'm going to close the connection on you"}
4> ibrowse:send_req("http://localhost:4567", [], get).
{error,connection_closing}
```

With this patch, ibrowse recreates a new connection on the next request.

```
2> ibrowse:set_dest("localhost", 4567, [{max_sessions, 1}]).
ok
3> ibrowse:send_req("http://localhost:4567", [], get).      
{ok,"200",
    [{"Content-Type","text/html;charset=utf-8"},
     {"Connection","close"},
     {"Content-Length","40"},
     {"X-XSS-Protection","1; mode=block"},
     {"X-Content-Type-Options","nosniff"},
     {"X-Frame-Options","SAMEORIGIN"},
     {"Server","thin 1.5.1 codename Straight Razor"}],
    "I'm going to close the connection on you"}
4> ibrowse:send_req("http://localhost:4567", [], get).      
{ok,"200",
    [{"Content-Type","text/html;charset=utf-8"},
     {"Connection","close"},
     {"Content-Length","40"},
     {"X-XSS-Protection","1; mode=block"},
     {"X-Content-Type-Options","nosniff"},
     {"X-Frame-Options","SAMEORIGIN"},
     {"Server","thin 1.5.1 codename Straight Razor"}],
    "I'm going to close the connection on you"}
```
