### PR TITLE
Fix bad call to io:format

### DIFF
--- a/src/ibrowse.erl
+++ b/src/ibrowse.erl
@@ -623,8 +623,8 @@ show_dest_status(Host, Port) ->
                       [Lb_pid, MsgQueueSize, Size]);
         no_active_processes ->
             io:format("No processes for destination~n");
-        _Err ->
-            io:format("Metrics not available: ~p~n", [])
+        Err ->
+            io:format("Metrics not available: ~p~n", [Err])
     end.
 
 get_metrics() ->


### PR DESCRIPTION
This generates a warning on every erchef build which annoys me.  This
bug doesn’t exist upstream but we are far behind upstream.

Signed-off-by: Steven Danna <steve@chef.io>