### PR TITLE
Fixed ibrowse_http_client - ssl options not passing to ssl:connect

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -577,10 +577,13 @@ do_connect(Host, Port, Options, #state{is_ssl      = true,
            Timeout) ->
     %% if a socks5 proxy is configured, open the socket separately
     %% before upgrading the socket to a TLS connection.
+    %% Extract SSL options from request Options and merge with state SSL options
+    RequestSSLOptions = get_value(ssl_opts, Options, []),
+    MergedSSLOptions = RequestSSLOptions ++ SSLOptions,
     case get_value(socks5_host, Options, undefined) of
         %% no socks5 proxy is configured, connect directly with TLS:
         undefined ->
-            Sock_options = get_sock_options(Host, Options, SSLOptions),
+            Sock_options = get_sock_options(Host, Options, MergedSSLOptions),
             ssl:connect(Host, Port, Sock_options, Timeout);
 
         %% proxy configuration is present: first establish a socket
@@ -591,7 +594,7 @@ do_connect(Host, Port, Options, #state{is_ssl      = true,
                                           Sock_options, Timeout),
             case Conn of
                 {ok, Sock} ->
-                    ssl:connect(Sock, SSLOptions, Timeout);
+                    ssl:connect(Sock, MergedSSLOptions, Timeout);
                 _ ->
                     error
             end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixed ibrowse_http_client - ssl options not passing to ssl:connect
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixed ibrowse_http_client - ssl options not passing to ssl:connect
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
